### PR TITLE
Minjeong / 3월 3주차 / 4문제

### DIFF
--- a/minjeong/Backtracking/2024-03-13-[백준]-#14888-연산자 끼워넣기.py
+++ b/minjeong/Backtracking/2024-03-13-[백준]-#14888-연산자 끼워넣기.py
@@ -1,0 +1,33 @@
+# 입력받기
+n = int(input()) # 수의 개수
+nums = list(map(int, input().split())) # 수열
+operator = list(map(int, input().split())) # 연산자
+
+# 최솟값, 최댓값 초기화
+minValue= 1000000000
+maxValue= -1000000000 
+
+def calculator(idx, res, add, sub, prd, div):
+    global minValue, maxValue
+
+    if idx == n: # 종료조건: 연산자를 모두 사용했을 경우
+        # 다 탐색했기 때문에 최대최소 비교해서 최솟값과 최댓값 갱신
+        maxValue = max(maxValue, res)
+        minValue = min(minValue, res)
+        return 
+    
+    if add > 0:
+        calculator(idx + 1, res + nums[idx], add-1, sub, prd, div)
+
+    if sub > 0:
+        calculator(idx + 1, res - nums[idx], add, sub-1, prd, div)
+
+    if prd > 0:
+        calculator(idx + 1, res * nums[idx], add, sub, prd-1, div)
+
+    if div > 0:
+        calculator(idx + 1, int(res / nums[idx]), add, sub, prd, div-1)
+
+calculator(1, nums[0], operator[0], operator[1], operator[2], operator[3])
+print(maxValue)
+print(minValue)

--- a/minjeong/Backtracking/2024-03-15-[백준]-#14889-스타트와 링크.py
+++ b/minjeong/Backtracking/2024-03-15-[백준]-#14889-스타트와 링크.py
@@ -1,0 +1,36 @@
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+S = [list(map(int, input().split())) for _ in range(N)]
+check = [False] * N
+minValue = 1000000000
+
+def calculate():
+    global minValue
+    Ateam = 0
+    Bteam = 0
+    for i in range(N):
+        for j in range(N):
+            if check[i] and check[j]:
+                Ateam += S[i][j]
+            if not check[i] and not check[j]:
+                Bteam += S[i][j]
+
+    minValue = min(minValue, abs(Ateam - Bteam))
+
+def backtracking(start, size):
+    global minValue
+    if size == N//2:
+        calculate()
+        return 
+
+    for i in range(start, N):
+        if check[i] == False:
+            check[i] = True
+            backtracking(i+1, size+1)
+            check[i] = False
+
+
+backtracking(0, 0)
+print(minValue)

--- a/minjeong/Stack, Queue/2024-03-12-[PGS]-캐시.py
+++ b/minjeong/Stack, Queue/2024-03-12-[PGS]-캐시.py
@@ -1,0 +1,27 @@
+from collections import deque
+
+def solution(cacheSize, cities):
+    totalTime = 0
+    cache = deque([])
+    '''
+    전체적인 과정은 FIFO로 수행된다.
+    만약 이미 존재하는 도시라면 맨 뒤로 다시 보낸다. 
+    '''
+
+    for i in range(len(cities)):
+        city = cities[i].lower()     # 대소문자 구분 없으므로 cities를 lowercase로 바꾸기
+        if cacheSize == 0:  # cacheSize가 0인 경우에 대한 예외처리(TC 7, 17)
+            totalTime += 5
+            continue    # 그 후 바로 빠져나옴
+        if city in cache:        # 캐시에 도시가 이미 존재하는 경우
+            cache.remove(city)
+            cache.append(city)
+            totalTime += 1 # cache hit
+        else:
+            if len(cache) == cacheSize and cacheSize > 0: # 캐시가 가득찼다면, 맨 앞에 하나 버린다. 이때 cacheSize가 0인 경우도 있다. 이때는 popleft하면 에러가 나므로 cacheSize가 0이상인 경우만 처리되도록 한다.                    
+                cache.popleft()
+            cache.append(city)
+            totalTime += 5 # cache miss
+            
+             
+    return totalTime

--- a/minjeong/String/2024-03-16-[Programmers]-#뉴스클러스터링.py
+++ b/minjeong/String/2024-03-16-[Programmers]-#뉴스클러스터링.py
@@ -1,0 +1,34 @@
+from collections import Counter
+
+def solution(str1, str2):
+    answer = 0
+    A = [] # str1 
+    B = [] # str2
+    
+	# str1과 str2 전처리: 2개씩 끊어서 저장하기
+    for i in range(len(str1)):
+        temp = str1[i:i+2].lower()  # 대소문자 구분 X
+        if temp.isalpha() and len(temp) == 2:
+            A.append(temp)
+            
+    for i in range(len(str2)):
+        temp = str2[i:i+2].lower()  # 대소문자 구분 X
+        if temp.isalpha() and len(temp) == 2:
+            B.append(temp)
+    
+    # Counter 객체로 변환 
+    A = Counter(A)
+    B = Counter(B)
+
+    # 교집합과 합집합 구하기
+    intersection = A & B
+    union = A | B
+    
+    # 합집합의 수가 0인 경우에 대한 예외처리
+    if sum(union.values()) == 0:
+        answer = 65536
+    else:
+        answer = int(sum(intersection.values()) / sum(union.values()) * 65536)
+
+    return answer
+    


### PR DESCRIPTION
- 푼 문제들의 플로우를 담았습니다. 문제 정리 열심히 했습니다.
1. [PGS] 캐시 (성공)
2. [PGS] 뉴스 클러스터링 (성공)
3. [BOJ] #14888. 연산자 끼워넣기 (힌트보고 겨우 성공)
4. [BOJ] #14889. 스타트와 링크  (실패)

# [PGS] 캐시 - deque 사용하여 문제 해결
[문제 정리 링크 바로 가기](https://minggirokkk.notion.site/9de8b73a60c84deab4a3ca06a02a399d?pvs=4)
- LRU라고 하였으므로, 큰 틀은 FIFO와 같이 처리되도록 하되, 한 번 사용된 것은 제거하고 다시 맨 뒤에 보내도록 한다. FIFO처럼 처리하기 위해서 deque 자료구조를 사용한다.
1. deque 자료구조인 `cache`를 초기화한다. 정답으로 반환할 `totalTime`도 초기화한다.
6. `cities`의 길이만큼 반복하여, 각 `city`를 처리한다.
    1. `city`는 대소문자 구분이 아니므로 모두 lowercase로 바꿔준다.
    2. `cacheSize`가 0인 경우에는 따로 예외처리를 해주도록 한다.
    7. `cache` 안에 `city`가 있는지 확인한다. 만약 있다면, 해댱 `city`를 제거한 후 다시 맨 뒤에 append한다. (최신으로 갱신) 또 cache hit이므로 `totalTime`에 1을 더한다.
        
        만약 없다면, cache miss이므로 `totalTime`에 5를 더한다. 그리고 가장 앞에 있는 것을 pop하고, 해당 `city`를 맨 뒤에 추가한다.
        
        - 이때, `cache`가 `cacheSize` 크기가 되고 `cacheSize`가 0이 아닐 때에는 다시 최근 것으로 넣도록 처리한다.
3. 반복문이 끝나면 `totalTime`을 반환한다.

# [PGS] 뉴스 클러스터링: Counter 클래스 사용하여 문제 해결
[문제 정리 링크 바로 가기](https://minggirokkk.notion.site/f89ce1ece77c4c8db6ad6938472c64de)
한번에 처리되진 않고, 크게 3단계로 구성된다.

1. **str1과 str2의 전처리하기**
2. **Counter 객체로 변환 후, 합집합과 교집합 구하기**
3. **자카드 유사도 계산하기**

1. **str1과 str2 전처리**
- 문제에서 나온 조건은 “대문자와 소문자의 차이는 무시한다.”와 “ 영문자로 된 글자 쌍만 유효하고, 기타 공백이나 숫자, 특수 문자가 들어있는 경우는 그 글자 쌍을 버린다”이다.
    
    ⇒ 따라서 영문자만 저장할 수 있도록 설정해야 한다.
    
- 두 글자씩 끊어야 한다.
    
    ⇒ 인덱스 슬라이싱을 이용한다.
    

```python
# str1과 str2 전처리: 2개씩 끊어서 저장하기
    for i in range(len(str1)):
        temp = str1[i:i+2].lower()  # 대소문자 구분 X
        if temp.isalpha() and len(temp) == 2:
            A.append(temp)
            
    for i in range(len(str2)):
        temp = str2[i:i+2].lower()  # 대소문자 구분 X
        if temp.isalpha() and len(temp) == 2:
            B.append(temp)
```

1. **Counter 객체로 변환 후, 합집합과 교집합 구하기**

전처리된 A(str1에 대한 리스트), B(str2에 대한 리스트)를 각각 Counter객체로 변환시켜준다.

```python
from collections import Counter

# 카운터 객체로 변환
A = Counter(A)
B = Counter(B)
```

이때 Counter 메서드는 각각의 리스트는 해당 원소값을 key값으로 하고, 원소의 갯수를 value값으로 하는 dictionary 형태의 구조를 반환한다.

예를 들어 str1 = FRANCE, str2 = french 라면, 이 로직을 거쳤을 경우 Counter1과 Counter2는 각각 다음의 값을 출력한다.

```python
print(Counter1, Couner2)
>>> Counter({'fr': 1, 'ra': 1, 'an': 1, 'nc': 1, 'ce': 1}) Counter({'fr': 1, 're': 1, 'en': 1, 'nc': 1, 'ch': 1})
```

교집합 연산은 `&`로, 합집합 연산은 `|` 으로 가능하다. 각각 계산해준다.

```python
# 교집합과 합집합 구하기
    intersection = A & B
    union = A | B
```

1. **자카드 유사도 계산**

이때 계산된 교집합과 합집합을 출력하면 아래와 같은 모습이다.

```python
print(intersection, union)

# Counter({'fr': 1, 'nc': 1}) Counter({'fr': 1, 'ra': 1, 'an': 1, 'nc': 1, 'ce': 1, 're': 1, 'en': 1, 'ch': 1})
```

따라서 key가 아닌 value들의 합으로 교집합의 개수와 합집합의 개수를 구한다.

```python
sum(intersection.values())
sum(union.values())
```

자카드의 유사도는 (교집합 갯수 / 합집합의 갯수)로 계산한다. 하지만 이 문제의 경우 자카드 유사도는 0에서 1사이의 실수로 나타나기 때문에 다루기 쉽도록 자카드 유사도에 65536을 곱한 뒤 정수 부분만 출력하도록 하였다.

그리고 나눌 때의 값이 0인 경우에는 계산할 수 없으므로, 이 경우에는 65536이 바로 출력되도록 설정한다.

```python
# 합집합의 수가 0인 경우에 대한 예외처리
    if sum(union.values()) == 0:
        answer = 65536
    else:
        answer = int(sum(intersection.values()) / sum(union.values()) * 65536)

```

# [BOJ] #14888. 연산자 끼워넣기: 백트래킹 이용
[문제 정리 링크 바로가기](https://minggirokkk.notion.site/14888-269556b0a5834b818a52fe39a4c0d702)

함수에 전달해야 할 인자들 중 필요한 값들:
- 연산자들 (+, -, *, /)
- 각 가지치기에 대한 계산값들
- 계산해야 하는 리스트의 인덱스 정보 (가지치고 난 후, 올라왔을 때 다시 인덱스가 0으로 바뀌어야 함)


종료조건
nums리스트의 마지막 인덱스까지 다 보면 종료

### TIL

- 파이썬 수 자료형
    - 주로 코딩테스트에서는 최댓값이 10억 미만일 경우 무한(INF)을 `1e9`로 표현한다.
    - 이때 `1e9` 는 정수가 아닌 실수이다.
    
    ```python
    a = 1e9
    b = int(1e9)
    c = 1000000000
    
    print('a : ' + str(a))
    print('b : ' + str(b))
    print('c : ' + str(c))
    print()
    
    a = min(a, c)
    print('a : ' + str(a))
    
    ##### 출력 결과 #####
    
    a : 1000000000.0
    b : 1000000000
    c : 1000000000
    
    a : 1000000000.0 # 여전히 실수인 채로 남아있다
    ```
    
- 예약어 변수명에 주의하자
- 문제 풀 때, 최솟값과 최댓값의 초기화를 하려면 아래와 같이
    1. 처음부터 int(1e9)로 정수로 변환하여 초기화 시켜두거나
    2. 아예 1e9+1과 같이 1e9보다 더 큰 값으로 초기화 해 두어10억이 들어왔을 때 새로운 정수로 갱신이 되도록 만들어야 한다.
    - 허탈한 실수를 막기 위해선 문제에 나와있는 조건을 **그대로 코드로 옮겨적는** 습관을 들이도록 하자

# [BOJ] #14889. 스타트와 링크 (너무 어려웠음): 백트래킹 이용
[문제 정리 링크](https://minggirokkk.notion.site/14889-3a931b25be6048a8b7a261a2013f41fd?pvs=4)

- 굳이 N개를 전체 다 재귀적으로 볼 필요가 없다. 절반을 만들면 나머지 절반이 자동으로 팀이 정해지기 때문이다.
- 그래서 먼저 1. 팀을 나누고, 2. 팀별로 점수를 계산해야 한다. 그 계산한 값 중 최솟값이 필요하다.

**팀 나누기**

- 팀으로 뽑혔는지 아닌지의 여부는 bool타입 리스트 `check`에  True와 False로 설정을 한다.
    - 그래서 백트래킹 탐색은 절반만(N//2만) 한다.
    - 팀원을 뽑으면 check를 True로 바꿔주고 백트래킹한다. 절반만 탐색하니 절반은 True, 절반은 False가 된다.
    - 백트래킹에서 빠져나오면 다시 False로 바꿔준다.
```python
def backtracking(start, size):
    global minValue
    if size == N//2:
        calculate()
        return 

    for i in range(start, N):
        if check[i] == False:
            check[i] = True
            backtracking(i+1, size+1)
            check[i] = False
```

**팀별로 점수 계산하기**

- 만약 1과 2가 한팀이면, 그 팀의 점수는 s[1][2] + s[2][1]이다.
- 만약 1,2,3이 한 팀이라면, s[1][2] + s[1][3] + s[2][1] + s[2][3] + s[3][1] + s[3][2] 이 된다.
- 문제에서는  Sii는 항상 0이라고 언급되어있다. 따라서 s[1][2] + s[1][3] + s[2][1] + s[2][3] + s[3][1] + s[3][2] 는 s[1][1] + s[1][2] + s[1][3] + s[2][1] + s[2][2] + s[2][3] + s[3][1] + s[3][2] + s[3][3] 과 같다.
    
    따라서 위와 같은 방법으로 각 팀의 점수를 구해줄 수 있다.
```python
def calculate():
    global minValue
    Ateam = 0
    Bteam = 0
    for i in range(N):
        for j in range(N):
            if check[i] == True and check[j] == True:
                Ateam += S[i][j]
            if check[i] == False and check[j] == False:
                Bteam += S[i][j]
             
    return min(minValue, abs(Ateam - Bteam))
```

### TIL
시간 초과가 될 때는 번거로운 , 불필요한 연산은 없는지 확인하도록 한다.
