### PR TITLE
Minjeong / 3월 5주차 / 4문제

### DIFF
--- a/minjeong/DynamicProgramming/2024-03-25-[백준]-#1932-정수삼각형.py
+++ b/minjeong/DynamicProgramming/2024-03-25-[백준]-#1932-정수삼각형.py
@@ -1,0 +1,21 @@
+import sys
+input = sys.stdin.readline
+
+# 입력값 저장
+n = int(input())
+arr = []
+for i in range(n):
+    temp = list(map(int, input().split()))
+    arr.append(temp)
+
+# DP 처리
+for i in range(1, n):
+    for j in range(0, i+1):
+        if j == 0:
+            arr[i][j] += arr[i-1][j]
+        elif j == i:
+            arr[i][j] += arr[i-1][j-1]
+        else:
+            arr[i][j] += max(arr[i-1][j], arr[i-1][j-1])
+# 최대 합
+print(max(arr[n-1]))

--- a/minjeong/DynamicProgramming/2024-03-27-[백준]-#1149-RGB거리.py
+++ b/minjeong/DynamicProgramming/2024-03-27-[백준]-#1149-RGB거리.py
@@ -1,0 +1,16 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+cost = []
+for i in range(n):
+    temp = list(map(int, input().split()))
+    cost.append(temp)
+
+# 0: RED, 1: GREEN, 2: BLUE
+for i in range(1, n):
+    cost[i][0] = min(cost[i-1][1], cost[i-1][2]) + cost[i][0] # RED
+    cost[i][1] = min(cost[i-1][0], cost[i-1][2]) + cost[i][1] # GREEN
+    cost[i][2] = min(cost[i-1][0], cost[i-1][1]) + cost[i][2] # BLUE
+
+print(min(cost[-1][0], cost[-1][1], cost[-1][2]))

--- a/minjeong/DynamicProgramming/2024-03-28-[백준]-#2579-계단오르기.py
+++ b/minjeong/DynamicProgramming/2024-03-28-[백준]-#2579-계단오르기.py
@@ -1,0 +1,17 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+stair = [0]*301
+for i in range(n):
+    stair[i]=int(input())
+
+DP = [0]*301
+DP[0] = stair[0]
+DP[1] = stair[0]+stair[1]
+DP[2] = max(stair[0]+stair[2], stair[1]+stair[2])
+
+for i in range(3, n):
+    DP[i] = max(DP[i-3] + stair[i-1] + stair[i], DP[i-2]+stair[i])
+
+print(DP[n-1])

--- a/minjeong/DynamicProgramming/2024-03-29-[백준]-#2156-포도주시식.py
+++ b/minjeong/DynamicProgramming/2024-03-29-[백준]-#2156-포도주시식.py
@@ -1,0 +1,20 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+wine = [0] * n
+for i in range(n):
+    wine[i] = int(input())
+
+dp = [0] * n
+dp[0] = wine[0]
+if n > 1:
+    dp[1] = wine[0] + wine[1]
+
+# n이 1보다 클 때만 두 번째 포도주부터 로직 실행
+for i in range(2, n):
+    # 현재 포도주를 마시지 않는 경우, 현재 포도주와 이전 포도주를 마시는 경우,
+    # 그리고 이전 포도주를 마시지 않고 현재 포도주를 마시는 경우를 고려
+    dp[i] = max(dp[i-1], dp[i-2] + wine[i], dp[i-3] + wine[i-1] + wine[i])
+
+print(dp[-1])


### PR DESCRIPTION
# 목표 문제 수: 4문제

>푼 문제
- [백준 #1932. 정수 삼각형](https://www.acmicpc.net/problem/1932): DP 실버1
- [백준 #1149. RGB 거리](https://www.acmicpc.net/problem/1149) : DP, 실버1
- [백준 #2569. 계단 오르기](https://www.acmicpc.net/problem/2569): DP, 실버3
- [백준 #2156. 포도주 시식](https://www.acmicpc.net/problem/2156): DP, 실버1

# [백준 #1932. 정수 삼각형](https://www.acmicpc.net/problem/1932): DP 실버1
[정리 링크 바로가기](https://minsllogg.tistory.com/entry/BOJ-1932-%EC%A0%95%EC%88%98%EC%82%BC%EA%B0%81%ED%98%95-Python-DP)

## 🔍Institution

1. 어떻게 동작 과정이 수행되는지 핸드트레이싱해본다.
2. 리스트를 어떻게 받아낼지 아이디어를 떠올린다.

이 2가지 과정을 거쳤다.

1. 어떻게 동작 과정이 수행되는지 핸드트레이싱해본다.
    
    ⇒ 대각선 왼쪽, 대각선 오른쪽만 이동할 수 있다. 
    
    이때, 양쪽 끝에 있는 부분은 그냥 그대로 내려받는다.
    
    그게 아니라면, max()를 이용해서 양쪽으로 내려오는 것들 중 더했을 때 더 큰 값을 다시 저장하도록 한다.
    

1. 리스트를 어떻게 받아낼 것인가?
    
    가장 간단한 방법은 중첩 리스트를 이용하는 것이다.
    
    ```python
    [[7], [3, 8], [8, 1, 0], [2, 7, 4, 4], [4, 5, 2, 6, 5]]
    ```
    

중첩리스트를 다시 한 번 살펴보자

```python
[[7],
[3, 8], 
[8, 1, 0], 
[2, 7, 4, 4], 
[4, 5, 2, 6, 5]]
```

이렇게 된 상태에서 동작과정을 살펴보도록 한다. 이때 2차원 리스트이기 때문에 2중 for문이 불가피하다. 또한, 문제의 제한사항에서도 2초, 최대범위 500이기에 2중 for문을 사용해도 문제가 없음을 확인하였다. 

바깥 for문의 인덱스는 i로, 안쪽 for문의 인덱스는 `j`라고 하였을 때

- `j`의 값이 0인  `7`, `3`, `8`, `2`, `4`의 경우는 같은 위치에 있는 값을 그대로 내려받는다.
1. 리스트를 어떻게 받아내야 할까?
    
    이 부분에 대해서도 고민을 많이 해보았다. 가장 간단한 방식은 중첩 리스트를 이용하는 것이다.
    
    ```python
    [[7], [3, 8], [8, 1, 0], [2, 7, 4, 4], [4, 5, 2, 6, 5]]
    ```
    

중첩리스트를 펼쳐보면 이러한 모습이다.

1. 리스트를 어떻게 할 것인가?
    
    이 부분에 대해서도 고민을 오래 하게 되었다.  가장 간단한 방식은 중첩 리스트를 이용하는 것이다.
    
    ```python
    [[7], [3, 8], [8, 1, 0], [2, 7, 4, 4], [4, 5, 2, 6, 5]]
    ```
    
2. 규칙 찾기
    
    ```python
    [[7],
     [3, 8],
     [8, 1, 0],
     [2, 7, 4, 4], 
     [4, 5, 2, 6, 5]]
    ```
    
- `j`의 값이 `i`의 값과 같아질 때에는 `j-1` 위치에 있는 값을 그대로 누적해서 더한다.
- 그게 아닐 경우에는 현재 위치(`j`)에 있는 값과 이전 값(`j-1`)에 있는 값 중 더했을 때 더 큰 값이 되는 값으로 누적하여 더한다. (`max()` 이용)

## 🔍Approach

1. 입력받기

```python
n = int(input())
arr = []

for i in range(n):
    temp = list(map(int, input().split()))
    arr.append(temp)
print(arr)
```

결과:

```python
# 입력
5
7
3 8
8 1 0
2 7 4 4
4 5 2 6 5
# 출력
[[7], [3, 8], [8, 1, 0], [2, 7, 4, 4], [4, 5, 2, 6, 5]]
```

1. DP 처리
- 바깥 for문의 인덱스는 `i`로, 안쪽 for문의 인덱스는 `j`라고 하였을 때
- `j`의 값이 0인  `7`, `3`, `8`, `2`, `4`의 경우는 같은 위치에 있는 값을 그대로 내려받는다.
- `j`의 값이 `i`의 값과 같아질 때에는 `j-1` 위치에 있는 값을 그대로 누적해서 더한다.
- 그게 아닐 경우에는 현재 위치(`j`)에 있는 값과 이전 값(`j-1`)에 있는 값 중 더했을 때 더 큰 값이 되는 값으로 누적하여 더한다. (`max()` 이용)

```python
for i in range(1, n):
    for j in range(0, i+1):
        if j == 0:
            arr[i][j] += arr[i-1][j]
        elif j == i:
            arr[i][j] += arr[i-1][j-1]
        else:
            arr[i][j] += max(arr[i-1][j], arr[i-1][j-1])
```


# [백준 #1149. RGB 거리](https://www.acmicpc.net/problem/1149) : DP, 실버1

## 🚩My submission

```python
import sys
input = sys.stdin.readline

n = int(input())
cost = []
for i in range(n):
    temp = list(map(int, input().split()))
    cost.append(temp)

# 0: RED, 1: GREEN, 2: BLUE
for i in range(1, n):
    cost[i][0] = min(cost[i-1][1], cost[i-1][2]) + cost[i][0] # RED
    cost[i][1] = min(cost[i-1][0], cost[i-1][2]) + cost[i][1] # GREEN
    cost[i][2] = min(cost[i-1][0], cost[i-1][1]) + cost[i][2] # BLUE

print(min(cost[-1][0], cost[-1][1], cost[-1][2]))
```

# [백준 #2569. 계단 오르기](https://www.acmicpc.net/problem/2569): DP, 실버3
[정리 링크 바로가기](https://minggirokkk.notion.site/2579-7c5f5e4d8e6444d3bd03d8bf2f7c67aa?pvs=4)

# 🔍Institution

>💡 **문제의 조건**


- 한 번에 한 계단 혹은 두 계단씩 오를 수 있다.
- 연속된 세 개의 계단을 모두 밟아서는 안된다. 단, 시작점은 계단에 포함되지 않는다.
- 마지막 도착 계단은 반드시 밟아야 한다

DP라서 규칙을 찾고 점화식을 세우는 것에 많은 시간을 썼다. 하지만 결론적으로 내 직관은 실패했다.

실패한 직관에 대해 먼저 소개하고, 그 다음에 성공한 코드를 설명하겠다. 

## 🔍**실패한 직관(내 풀이 접근 방식)**

- dp테이블은 [ index, 누적합 ] 으로 구성된 중첩리스트로 정의한다.
- dp테이블에 들어가는 점화식은:
    - 현재 i가 dp를 바라보고 있는 index와 1개 이하 차이 나는 경우(연달아서 계단을 오를 수 없다.) 그리고 index가 벗어나지 않는 범위 한도
        
        ⇒ 연달아서 계단을 오를 수 없고 2칸의 차이를 둬야하므로, dp[i+2]에 저장한다.
        
    
    ```python
    dp[i+2] = [i, max(dp[i+2][1], dp[i][1] + stairs[i+2])]
    ```
    
    - 그게 아닐 경우,
        
        ⇒ 연달아서 오를 수도 있고, 2칸 뛰어서 오를 수도 있다. 더 큰 값으로 누적합을 더해준다.
        
        ```python
           dp[i+1] = [i, max(dp[i+1][1], stairs[i+1] + dp[i][1])]
          if i <= n-3:
              dp[i+2] = [i, max(dp[i+2][1], stairs[i+2] + dp[i][1])]
          
        ```
## 🔍**성공한 풀이의 직관**

- DP에 저장할 값은 DP[i]번째까지 왔을 때 점수의 최대값이다. 계단의 점수가 stair 리스트에 저장되어 있다고 가정하고, 점화식을 만들기 위해 예시를 확인해보면 아래와 같다.

**1. 첫 번째 계단**

DP[0] = stair[0]

**2. 두 번째 계단**

DP[1] = stair[0] + stair[1]

**3. 세 번째 계단**

DP[2] = stair[1] + stair[2] 혹은 stair[0] + stair[2]

둘 중 큰 값을 고른다.

**4. 네 번째 계단**

DP[4] = stair[0] + stair[1] + stair[3] + stair[4] 혹은 stair[0] + stair[2] + stair[4]

네 번째 계단을 보면, 겹치는 값들이 보인다. 해당 값을 DP를 활용해서 변경해보면 아래와 같다.

```python
DP[4] = DP[1]+stair[3]+stair[4] 혹은 DP[2]+stair[4]
```

위에 두 개의 식 중에 더 큰 값을 DP에 저장하게 됩니다. 이를 점화식으로 나타내면 아래와 같다.

```python
**DP[i] = max(DP[i-3] + stair[i-1] + stair[i], DP[i-2]+stair[i])**
```

## 💡TIL

- lambda를 이용하여 정렬하기! ← 맨날 까먹는다…
    
    ```python
    arr = [[2,3],[1,2],[0,4]]
    
    arr.sort(key=lambda x:x[0])
    
    print(arr)
    # [[0, 4], [1, 2], [2, 3]]
    ```
    
    이 때, x 값에 -를 취해주면 내림차순 정렬을 할 수 있다.
    
    ```python
    arr = [[2,3],[1,2],[0,4]]
    
    arr.sort(key=lambda x: -x[0])
    
    print(arr)
    # [[2, 3], [1, 2], [0, 4]]
    ```
    
    출처: https://asxpyn.tistory.com/75 [coding scent:티스토리]
    
- 처음엔 무작정 규칙을 찾아서 해결해보려고 시도했고, 결국엔 실패했다. 한 칸 올라왔을 때, 두 칸 올라왔을 때 등등 경우의 수가 많고 코드가 점점 더 복잡해지게 되었다. DP유형이라는 것을 인지했다면 최댓값을 찾는 것이 가장 큰 목적이 되고, DP에 저장할 값 역시 최댓값이 되어야 한다.
- dp라고 되었을 때 복잡하게 가는 것이 절대 정답이 아니고 최댓값을 찾는 방향을 찾도록 한다. 또한 i=0, i=1, i=2, i=3 … 의 경우일 때의 명확한 dp값을 구하여 규칙을 찾고 그 규칙에서 “점화식”을 찾는다. 점화식이 여러 개 일 필요는 없다.

# [백준 #2156. 포도주 시식](https://www.acmicpc.net/problem/2156): DP, 실버1
[정리 링크 바로가기](https://minggirokkk.notion.site/2156-bdfb6f1b76bc436f94a033d9bc36caf1?pvs=4)


보다보면 겹치는 부분들이 있다. i=0~i=2인 경우까지는 있어야지 그 다음부터 dp테이블을 활용할 수 있다. 따라서 아래와 같이 초기 설정을 한다.

```python
dp[0] = wine[0]
dp[1] = wine[0] + wine[1]
dp[2] = max(wine[0] + wine[2], wine[1] + wine[2])
```

i = 3일때는 아래와 같다.

```python
dp[3] = max(dp[i-3] + wine[i-1] + wine[i], dp[i-2] + wine[i])
```

이를 토대로 점화식으로 표현해보면 아래와 같다.

```python
 dp[i] = max(dp[i-3] + wine[i-1] + wine[i], dp[i-2] + wine[i])
```

# 🔍Approach

위의 점화식을 토대로 코드를 짰다.

1. 입력받은 값을 `wine` 리스트에 저장한다.
2. `dp` 리스트에 위에서 짠 점화식대로 코드를 진행한다.
3. `dp`테이블의 가장 마지막 값을 출력시킨다.

## 🚩My submission

### ❌1차 시도 ⇒ 실패

```jsx
import sys
input = sys.stdin.readline

n = int(input())
wine = [0] * n
for i in range(n):
    wine[i] = int(input())

dp = [0] * n
dp[0] = wine[0]
dp[1] = wine[0] + wine[1]
dp[2] = max(wine[0] + wine[2], wine[1] + wine[2])

for i in range(3, n):
    dp[i] = max(dp[i-3] + wine[i-1] + wine[i], dp[i-2] + wine[i])
print(max(dp))

```

![Untitled](https://prod-files-secure.s3.us-west-2.amazonaws.com/13dd0972-4b14-4a5a-a69d-46aafd0b55bf/066aa1e2-4f53-481f-be75-04087c5ad3ed/Untitled.png)

### ✅원인 파악 후 2차 시도

1. **인덱스 범위 오류**

n의 범위는 1이상이다. 이때 n이 2이하일 경우는 아래 구문이 실행될 때 인덱스 에러가 발생하게 된다.

```python
dp[1] = wine[0] + wine[1]
dp[2] = max(wine[0] + wine[2], wine[1] + wine[2])
```

따라서 이에 대해서 `n`이 1이나 2인 경우에 대해 별도로 처리해야 한다.

1. **올바르지 않은 점화식** 
- `n` 의 값에 따라 기본 케이스를 설정해야 한다. `n=1` 인 경우에는 바로 dp[0]의 값이 리턴이 되면 되기 때문에 for문으로 들어올 필요가 없다.
- 점화식을 쓰는 부분인 for문 안에서:
    - **`i`**번째 포도주를 마시고 **`i-1`**번째 포도주를 마시지 않는 경우,
    - **`i`**번째 포도주를 마시고 **`i-1`**번째 포도주도 마시는 경우,
    - **`i`**번째 포도주를 마시지 않는 경우
    - 이렇게 3가지를 모두 고려해야 한다.
- 이에 대한 점화식은
    
    ```python
    dp[i] = max(dp[i-1], dp[i-2] + wine[i], dp[i-3] + wine[i-1] + wine[i])
    ```
    
    이다. 
    
    내가 처음에 짰던 점화식(`dp[i] = max(dp[i-3] + wine[i-1] + wine[i], dp[i-2] + wine[i])`)과 비교했을 때에 dp[i-1]가 추가되었다.
    

**결론적으로 모든 포도주 잔에 대해 최대 포도주 양을 구하기 위해서는 3가지 사항을 고려해야 한다.**

1. 현재 포도주를 마시지 않는 경우(**`dp[i-1]`**)
2. 현재 포도주와 바로 이전 포도주(**`i-1`**)를 마시지 않고, 그 이전 포도주(**`i-2`**)와 현재 포도주를 마시는 경우(**`dp[i-2] + wine[i]`**)
3. 현재 포도주와 이전 두 포도주 중 하나(**`i-1`**)만 마시고, 그 이전의 포도주(**`i-3`**)도 마시는 경우(**`dp[i-3] + wine[i-1] + wine[i]`**)

```python
import sys
input = sys.stdin.readline

n = int(input())
wine = [0] * n
for i in range(n):
    wine[i] = int(input())

dp = [0] * n
dp[0] = wine[0]

# n이 1보다 클 때만 두 번째 포도주부터 로직 실행. n = 1인 경우, 바로 출력문으로 감
if n > 1:
    dp[1] = wine[0] + wine[1]

for i in range(2, n):
    # 현재 포도주를 마시지 않는 경우, 현재 포도주와 이전 포도주를 마시는 경우,
    # 그리고 이전 포도주를 마시지 않고 현재 포도주를 마시는 경우를 고려
    dp[i] = max(dp[i-1], dp[i-2] + wine[i], dp[i-3] + wine[i-1] + wine[i])

print(dp[-1])

```

## 💡TIL

- 좀 더 발전시킬 수 있는 방향: `wine`과 `dp`의 크기를 `n+1`로 설정하여 ⇒ 포도주 잔의 번호와 직접적으로 연결할 수 있다. 이렇게 되면 코드의 가독성도 높이고 실수를 줄일 수 있다고 한다.
    
    ```python
    import sys
    input = sys.stdin.readline
    
    n = int(input())
    wine = [0] * (n + 1)  # 포도주 양을 저장하는 리스트의 크기를 n+1로 조정
    for i in range(1, n + 1):
        wine[i] = int(input())
    
    dp = [0] * (n + 1)  # dp 테이블도 n+1로 조정
    dp[1] = wine[1]
    if n > 1:
        dp[2] = wine[1] + wine[2]
    
    # n이 2보다 클 때만 세 번째 포도주부터 로직 실행
    for i in range(3, n + 1):
        # 현재 포도주를 마시지 않는 경우, 현재 포도주와 이전 포도주를 마시는 경우,
        # 그리고 이전 포도주를 마시지 않고 현재 포도주를 마시는 경우를 고려
        dp[i] = max(dp[i-1], dp[i-2] + wine[i], dp[i-3] + wine[i-1] + wine[i])
    
    print(dp[n])
    
    ```
    
- dp의 규칙성과 점화식을 세우는 것이 이렇게 어려울 줄 몰랐다. 만만할 줄 알았는데 생각보다 많이 헤매었던 문제였다. 또 코드가 안 되는 부분을 원인을 찾으면서 많이 배웠다. n의 최댓값만 보는 것이 아니라 최솟값도 파악하여 인덱스 out of range가 되지 않도록 항상 고려해야겠다.
- max()에는 2가지 argument만 올 수 있는 게 아니라 3가지도 올 수 있다는 것을 알게 되었다.
- 점화식을 세울 때에는:
    - 기본 케이스를 설정해야 한다.
    - 점화식을 어디부터 적용해야 할지 파악해야 한다.


