### PR TITLE
Minjeong / 4월 4주차 / 5문제

### DIFF
--- a/minjeong/BitMasking/2024-04-25-[백준]-#11723-집합.py
+++ b/minjeong/BitMasking/2024-04-25-[백준]-#11723-집합.py
@@ -1,0 +1,23 @@
+import sys
+input = sys.stdin.readline
+
+m = int(input()) # 수행해야 하는 연산의 수
+s = 0 # 비어있는 초기 공집합 S
+for _ in range(m):
+    command = list(map(str, input().strip().split())) # 수행해야 하는 연산 -> all과 empty가 있으므로 리스트로 저장
+    # 따라서 command[0]: 연산내용 command[1]: 요소
+    if command[0] == 'add':         # 원소 추가 (or)
+        s |= (1 << int(command[1]))
+    elif command[0] == 'remove':    # 원소 삭제 (not + and)
+        s &= ~(1 << int(command[1]))
+    elif command[0] == 'check':     # 원소 체크
+        if s & (1<< int(command[1])):
+            print(1)
+        else:
+            print(0)
+    elif command[0] == 'toggle':    # 원소 토글 (xor)
+        s ^= (1 << int(command[1]))
+    elif command[0] == 'all':       # 원소 채우기
+        s = (1 << 21) - 1           
+    elif command[0] == 'empty':     #원소 비우기
+        s = 0

--- a/minjeong/DFSBFS/2024-04-28-[백준]-#1012-유기농배추.py
+++ b/minjeong/DFSBFS/2024-04-28-[백준]-#1012-유기농배추.py
@@ -1,0 +1,38 @@
+import sys
+sys.setrecursionlimit(10000) #재귀 limit 설정(파이썬 최대 깊이 늘리는 모듈 이용)
+
+input = sys.stdin.readline
+# dfs 함수 정의
+def dfs(x, y):
+    # x와 y의 위치가 벗어나거나, 양배추리스트에 없는 위치라면 그냥 반환
+    if x < 0 or x >= M or y < 0 or y >= N  or cabbage_filed[x][y] == 0:
+        return
+    
+    # 현재 위치 방문 처리 
+    cabbage_filed[x][y] = 0 # 배추 있던 자리 1->0으로 변경해서 중복 방지
+
+    # 상하좌우 위치 탐색
+    dfs(x+1, y) # 오른쪽 배추 탐색
+    dfs(x-1, y) # 왼쪽 배추 탐색
+    dfs(x, y+1) # 위쪽 배추 탐색
+    dfs(x, y-1) # 아래쪽 배추 탐색
+
+
+T = int(input()) # 테스트케이스 수
+for _ in range(T):
+    M, N, K = map(int, input().strip().split()) # M: 가로길이, N: 세로길이, K: 배추개수
+    cabbage_filed = [[0] * N for _ in range(M)] # 양배추밭 리스트 초기화
+    
+    for _ in range(K):
+        x, y = map(int, input().strip().split())
+        cabbage_filed[x][y] = 1 # 입력받은 x, y 위치에 배추가 있으므로 1로 변경
+    
+    worms = 0 # 지렁이 필요 수 초기화
+    for i in range(M):
+        for j in range(N):
+            if cabbage_filed[i][j] == 1: # 배추가 심어져 있고 아직 방문하지 않은 경우
+                worms += 1 # 지렁이 수 +1
+                dfs(i, j)# dfs 호출하여 모든 연결된 배추 방문 처리
+                
+
+    print(worms) # 현재 테스트케이스에 대한 지렁이 수 출력

--- a/minjeong/DFSBFS/2024-04-28-[백준]-#1012-유기농배추.py
+++ b/minjeong/DFSBFS/2024-04-28-[백준]-#1012-유기농배추.py
@@ -2,7 +2,8 @@ import sys
 sys.setrecursionlimit(10000) #재귀 limit 설정(파이썬 최대 깊이 늘리는 모듈 이용)
 
 input = sys.stdin.readline
-# dfs 함수 정의
+
+# 1. DFS 함수 정의
 def dfs(x, y):
     # x와 y의 위치가 벗어나거나, 양배추리스트에 없는 위치라면 그냥 반환
     if x < 0 or x >= M or y < 0 or y >= N  or cabbage_filed[x][y] == 0:
@@ -19,15 +20,19 @@ def dfs(x, y):
 
 
 T = int(input()) # 테스트케이스 수
+# 2. 입력 설정 및 초기화
 for _ in range(T):
     M, N, K = map(int, input().strip().split()) # M: 가로길이, N: 세로길이, K: 배추개수
     cabbage_filed = [[0] * N for _ in range(M)] # 양배추밭 리스트 초기화
     
+    # 3. 배추 위치 설정
     for _ in range(K):
         x, y = map(int, input().strip().split())
         cabbage_filed[x][y] = 1 # 입력받은 x, y 위치에 배추가 있으므로 1로 변경
     
     worms = 0 # 지렁이 필요 수 초기화
+    
+    # 4. DFS로 연결된 배추 탐색 & 지렁이 수 계산
     for i in range(M):
         for j in range(N):
             if cabbage_filed[i][j] == 1: # 배추가 심어져 있고 아직 방문하지 않은 경우
@@ -35,4 +40,5 @@ for _ in range(T):
                 dfs(i, j)# dfs 호출하여 모든 연결된 배추 방문 처리
                 
 
+		# 5. 결과 출력
     print(worms) # 현재 테스트케이스에 대한 지렁이 수 출력

--- a/minjeong/Graph/2024-04-28-[백준]-#1012-유기농배추.py
+++ b/minjeong/Graph/2024-04-28-[백준]-#1012-유기농배추.py
@@ -1,0 +1,38 @@
+import sys
+sys.setrecursionlimit(10000) #재귀 limit 설정(파이썬 최대 깊이 늘리는 모듈 이용)
+
+input = sys.stdin.readline
+# dfs 함수 정의
+def dfs(x, y):
+    # x와 y의 위치가 벗어나거나, 양배추리스트에 없는 위치라면 그냥 반환
+    if x < 0 or x >= M or y < 0 or y >= N  or cabbage_filed[x][y] == 0:
+        return
+    
+    # 현재 위치 방문 처리 
+    cabbage_filed[x][y] = 0 # 배추 있던 자리 1->0으로 변경해서 중복 방지
+
+    # 상하좌우 위치 탐색
+    dfs(x+1, y) # 오른쪽 배추 탐색
+    dfs(x-1, y) # 왼쪽 배추 탐색
+    dfs(x, y+1) # 위쪽 배추 탐색
+    dfs(x, y-1) # 아래쪽 배추 탐색
+
+
+T = int(input()) # 테스트케이스 수
+for _ in range(T):
+    M, N, K = map(int, input().strip().split()) # M: 가로길이, N: 세로길이, K: 배추개수
+    cabbage_filed = [[0] * N for _ in range(M)] # 양배추밭 리스트 초기화
+    
+    for _ in range(K):
+        x, y = map(int, input().strip().split())
+        cabbage_filed[x][y] = 1 # 입력받은 x, y 위치에 배추가 있으므로 1로 변경
+    
+    worms = 0 # 지렁이 필요 수 초기화
+    for i in range(M):
+        for j in range(N):
+            if cabbage_filed[i][j] == 1: # 배추가 심어져 있고 아직 방문하지 않은 경우
+                worms += 1 # 지렁이 수 +1
+                dfs(i, j)# dfs 호출하여 모든 연결된 배추 방문 처리
+                
+
+    print(worms) # 현재 테스트케이스에 대한 지렁이 수 출력

--- a/minjeong/Graph/2024-04-28-[백준]-#1012-유기농배추.py
+++ b/minjeong/Graph/2024-04-28-[백준]-#1012-유기농배추.py
@@ -2,7 +2,8 @@ import sys
 sys.setrecursionlimit(10000) #재귀 limit 설정(파이썬 최대 깊이 늘리는 모듈 이용)
 
 input = sys.stdin.readline
-# dfs 함수 정의
+
+# 1. DFS 함수 정의
 def dfs(x, y):
     # x와 y의 위치가 벗어나거나, 양배추리스트에 없는 위치라면 그냥 반환
     if x < 0 or x >= M or y < 0 or y >= N  or cabbage_filed[x][y] == 0:
@@ -19,15 +20,19 @@ def dfs(x, y):
 
 
 T = int(input()) # 테스트케이스 수
+# 2. 입력 설정 및 초기화
 for _ in range(T):
     M, N, K = map(int, input().strip().split()) # M: 가로길이, N: 세로길이, K: 배추개수
     cabbage_filed = [[0] * N for _ in range(M)] # 양배추밭 리스트 초기화
     
+    # 3. 배추 위치 설정
     for _ in range(K):
         x, y = map(int, input().strip().split())
         cabbage_filed[x][y] = 1 # 입력받은 x, y 위치에 배추가 있으므로 1로 변경
     
     worms = 0 # 지렁이 필요 수 초기화
+    
+    # 4. DFS로 연결된 배추 탐색 & 지렁이 수 계산
     for i in range(M):
         for j in range(N):
             if cabbage_filed[i][j] == 1: # 배추가 심어져 있고 아직 방문하지 않은 경우
@@ -35,4 +40,5 @@ for _ in range(T):
                 dfs(i, j)# dfs 호출하여 모든 연결된 배추 방문 처리
                 
 
+		# 5. 결과 출력
     print(worms) # 현재 테스트케이스에 대한 지렁이 수 출력

--- a/minjeong/Greedy/2024-04-24-[백준]-#1641-잃어버린괄호.py
+++ b/minjeong/Greedy/2024-04-24-[백준]-#1641-잃어버린괄호.py
@@ -1,0 +1,13 @@
+nums = input()
+nums_list = nums.split('-') # 1. 먼저 -를 기준으로 나눈다.
+
+for i, n in enumerate(nums_list):
+    num_plus = list(map(int, n.split('+'))) # 2. +를 기준으로 나눈 후, 리스트에 int로 바꿔 저장한다.
+    # 저장형태: [55, [50, 50]]
+    nums_list[i] = sum(num_plus) # 3. 바꾼 int형을 더한 값을 원래의 식이 있는 리스트에 저장한다.
+
+result = nums_list[0]
+for i in range(1, len(nums_list)): # 4. 나머지 값들을 - 연산한다.
+    result -= nums_list[i]
+
+print(result)

--- a/minjeong/PrefixSum/2024-04-26-[백준]-#11659-구간합구하기4.py
+++ b/minjeong/PrefixSum/2024-04-26-[백준]-#11659-구간합구하기4.py
@@ -1,0 +1,16 @@
+import sys
+input = sys.stdin.readline
+
+N, M = map(int, input().strip().split())
+nums = list(map(int, input().strip().split()))
+prefix = [0] * (N+1) 
+
+# 누적합 구하기
+for i in range(len(nums)):
+    prefix[i+1] = nums[i] + prefix[i]
+
+# 구간합 구하기 (누적합 - 구간)
+for _ in range(M):
+    start, end = map(int, input().strip().split())
+    result = prefix[end] - prefix[start-1] # 누적
+    print(result)

--- a/minjeong/PrefixSum/2024-04-27-[백준]-#2559-수열.py
+++ b/minjeong/PrefixSum/2024-04-27-[백준]-#2559-수열.py
@@ -1,0 +1,18 @@
+import sys
+input = sys.stdin.readline
+# N: 온도를 측정한 전체 날짜 수 / K: 연속적인 날짜의 수
+N, K = map(int, input().strip().split()) 
+temp = list(map(int, input().strip().split())) # 온도 리스트
+prefix_sum = [0] * (N+1)  # 누적합 리스트
+section = N - K + 1       # 구간합 리스트를 초기화하기 위한 크기
+range_sum = [0] * section # 구간합 리스트
+
+# 누적합 구하기
+for i in range(len(temp)):
+    prefix_sum[i+1] = temp[i] + prefix_sum[i]
+
+# 구간합 구하기
+for i in range(K, section+K):
+    range_sum[i-K] = prefix_sum[i] - prefix_sum[i-K] 
+
+print(max(range_sum)) # K일의 온도의 합이 최대가 되는 값


### PR DESCRIPTION
# 목표 문제 수: 3개

> **푼 문제**
- [백준 #1541. 잃어버린 괄호](https://www.acmicpc.net/problem/1541): 그리디 / 실버2
- [백준 #11723. 집합](https://www.acmicpc.net/problem/11723): 비트마스킹 / 실버5
- [백준 #11659. 구간 합 구하기4](https://www.acmicpc.net/problem/11659): 누적합(prefix Sum)/ 실버3
- [백준 #2559. 수열](https://www.acmicpc.net/problem/2559): 누적합(prefix Sum) / 실버3
- [백준 #1012. 유기농 배추](https://www.acmicpc.net/problem/1012): DFSBFS/ 실버2

아래는 제가 정리한 내용 중에서, 핵심이 되는 플로우와 TIL 위주를 가져왔습니다. 

---

## [백준 #1541. 잃어버린 괄호](https://www.acmicpc.net/problem/1541): 그리디 / 실버2
정리한 노션 링크: [노션](https://minggirokkk.notion.site/1541-f18c2ff7731a471a880879854d592441?pvs=4)

### 🔍Intuition
- `-`를 기준으로 나눈다(=괄호를 친다)
- 이후 `+`를 기준으로 나누고 연산을 진행한다
- 그 이후 `-` 연산을 진행한다

> 예시: 3 + 10 - 5 - 8 + 24 
⇒ 3 + 10 - 5 - ( 8 + 24 ) = 8 - 31 = -23
> 
1. `-`를 기준으로 나눈다.
    
    `3+10` `5` `8+24` 
    
2. 이후 `+` 기준으로 나누어 연산을 진행한다
    
    `13` `5` `31`
    
3. 그 다음 각 문자열간 `-` 연산을 진행한다
    
    `13` `-` `5` `-` `31` 
    
    = -23
    
4. 이는 괄호를 친 연산결과와 동일하게 나온다.

### 🚩**플로우**
> 🎯 **문제의 핵심: 첫 번쨰 마이너스 연산 이후 나오는 모든 수를 괄호로 묶어 최대한 큰 값을 뺀다!**
→ 즉 첫번째 `-` 이후 모든 `+` 연산을 먼저 수행하고, 그 결과를 첫번째 수에서 빼는 방식

### 🚩My submission
```python
nums = input()
nums_list = nums.split('-') # 1. 먼저 -를 기준으로 나눈다.

for i, n in enumerate(nums_list):
    num_plus = list(map(int, n.split('+'))) # 2. +를 기준으로 나눈 후, 리스트에 int로 바꿔 저장한다.
    # 저장형태: [55, [50, 50]]
    nums_list[i] = sum(num_plus) # 3. 바꾼 int형을 더한 값을 원래의 식이 있는 리스트에 저장한다.

result = nums_list[0]
for i in range(1, len(nums_list)): # 4. 나머지 값들을 - 연산한다.
    result -= nums_list[i]

print(result)
```

### 💡TIL
- str형태로 저장이 되어 리스트에서 바로 연산할 때 헷갈렸는데, `리스트의 문자열을 int 형태로 변환`을 검색해서 찾아보니까 입력하여 저장할 때 자주 사용하던 `map`함수가 나왔다. map함수의 용도에 대해 다시 한번 제대로 알게 되었다.
    - `list_a = ['1', '2', '3', '4']`  →  `list_a = [1, 2, 3, 4]` 로 바꾸고 싶을 때,
        
        ```python
        # python2
        list_a =map(int, list_a)
        # python3
        list_a =list(map(int, list_a))
        ```
        
        ```python
        list_a = [int (i) for i in list_a]
        ```
        
        를 해주면 된다.
        
- 이 문제가 왜 그리디 알고리즘 유형인지 처음엔 이해하기 어려웠다. 정확히는 브루트포스인지, 그리디인지 이 문제의 유형이 어떤 유형인지 파악이 어려웠다.
    - 결론적으로는 **그리디 알고리즘**이다.
    - **브루트포스**: 모든 경우의 수를 탐색하여 문제 해답을 찾는 방식
    - **그리디**: 각 단계에서 가장 좋아보이는 선택하는 방식으로, 지역적인 최적 선택을 통해 전체적인 최적해를 구하는 방식.
        - 각 단계의 선택은 이후 선택에 영향을 미치지 않고, 한 번 수행된 선택은 번복되지 않는다.
    - **이 문제는 왜 그리디 알고리즘인가?**
        
        제시된 문제를 통해 식을 최소화하기 위해 최적의 괄호 배치를 찾는다. **⇒ 이를 통해 첫 번째 나오는 `-` 연산자 이후 모든 `+` 결과를 가능한 크게 만들어 전체 식의 결과를 최소화시킨다. 이를 위해서 각 단계에서 괄호를 통해 최적의 선택**한다.
        
        ⇒  `-` 이후에 최대한 큰 값을 더하고 빼는 방식이 전체 값을 최소화하는 유일한 방법이므로 그리디 알고리즘 사용이 적합

---

## [백준 #11723. 집합](https://www.acmicpc.net/problem/11723): 비트마스킹 / 실버5
정리한 노션 링크: [노션](https://minggirokkk.notion.site/11723-928cd2b4e273473994e11ad9378d7c93?pvs=4)

## 🔍비트마스크의 개념

컴퓨터는 내부적으로 bit 단위로 연산을 한다. bit는 모두 익히 알 듯이 0과 1로만 이루어져 있는데 이 특징을 이용해서 다양한 알고리즘 문제에서 간결한 코드와 빠른 속도로 활용이 가능하다.

가령, 10개의 방문을 체크해야 한다면 보통 `check = [False] * 10`와 같이 리스트를 많이 사용한다. 비트 마스킹은 아래와 같이 표현해서 하위 주소인 오른쪽부터 0인지 1인지 확인하면 된다.

```python
check = 0b0000000000
```

## 비트 연산자

1. **& (AND)**
    - 비교하는 비트가 둘 다 참일 때 만족
    - 0011 & 0110 = 0010
2. **| (OR)**
    - 비교 하는 비트 둘 중 하나라도 참이면 만족
    - 0011 | 0110 = 0111
3. **^ (XOR)**
    - 비교 하는 비트가 서로 달라야 만족
    - 0011 ^ 0110 = 0101
4. **~ (NOT)**
    - 보수 연산 0->1, 1->0
    - a가 0011일 때, ~a는 1100
5. `**<<` (왼쪽 shift)**
    - 특정 값 n만큼 왼쪽으로 비트 이동
    - a가 0011일 때, a << 2는 1100
    - 2^n를 곱한만큼 값이 증가
6. `**>>` (오른쪽 shift)**
    - 특정 값 n만큼 오른쪽으로 비트 이동
    - a가 0110일 때, a << 1는 0011
    - 2^n을 나눈만큼 값이 감소

## 🔍비트마스크와 집합

비트 마스크는 비트의 특징을 살려 **집합** 개념의 문제에서 활용이 가능하다. [[백준 11723 집합](https://www.acmicpc.net/problem/11723)](https://www.acmicpc.net/problem/11723) 문제가 비트 마스킹으로 집합을 구현하는 문제이다.

python에서 집합은 `set()`을 통해 쉽게 사용 가능하지만, 비트마스크를 이용할 수도 있다. 원소의 개수가 n인 집합이 있다고 했을 때, 각 *원소에 대하여 0에서 n-1까지의 번호를 부여* 하여 부분집합을 나타낼 수 있다. **번호에 해당하는 비트 하나하나가 원소의 존재 여부**를 의미한다. 비트가 1이면 해당 원소가 집합에 포함되어 있다는 것이고, 0이면 포함되지 않았다는 것이다.

### 원소 추가

앞으로 집합은 S, 특정 원소의 값은 num이라고 하겠다.

S에 num을 추가한다는 것은 S의 num번 비트에 1을 채운다는 의미이다. shift 연산을 통해 비트 1을 num만큼 왼쪽으로 이동시키고, 이를 S와 or 연산해주면 S의 num번 비트에 1이 채워진다.

```python
S |= (1<<num)
```

### 원소 삭제

S에서 num을 삭제한다는 것은 S의 num번 비트에 0을 채운다는 의미이다. shift 연산을 통해 비트 1을 num만큼 왼쪽으로 이동시키고 not 연산을 진행한다. 그러면 모든 비트가 반전되기 때문에 num번 비트는 0, num번 비트를 제외한 모든 비트가 1이 된다. 이를 S와 and 연산해주면 S의 num번 비트만 0이 된다.

```python
S &= ~(1<<num)
```

### 원소 토글

S에 num이 없다면 추가, 있다면 삭제하는 연산이다. 비교하는 비트가 서로 다를 때 1을 반환하는 연산인 xor을 활용하면 쉽게 구현 가능하다. shift 연산을 통해 비트 1을 num만큼 왼쪽으로 이동시키고, 이를 S와 ^연산을 해주면 된다.

```python
S ^= (1<<num)
```

### 원소 조회

S에 num의 존재 여부를 확인해 있다면 1, 없다면 0을 출력해준다. 이는 두 비트가 모두 1이여야 1을 반환하는 and 연산을 활용하면 된다. shift 연산을 통해 비트 1을 num만큼 왼쪽으로 이동시킨 뒤, 이를 S와 and 연산을 통해 값이 존재한다면 1을, 존재하지 않다면 0을 반환한다.

```python
print(1 if S & (1<<num) != 0 else 0)
```

### 원소 비우기 & 채우기

S의 모든 원소를 비우는 것은 단순히 0으로 초기화하여 모든 비트를 0으로 만들어주면 된다. S의 모든 원소를 채울 땐 모든 비트를 1로 만들어 주어야하는데, 이는 shift 연산을 통해 비트 1을 `집합의 크기 + 1` 만큼 왼쪽 이동시킨 뒤 1을 빼준다. 이렇게 되면 비트의 자릿수가 하나 줄게 되면서 집합의 크기만큼 공간이 생기고, 그 공간들엔 모두 비트 1로 채워질 것이다. (1000000-1=111111)

```python
S = 0              #비우기
S = (1 << 21) - 1  #채우기
# S=(1<<S의 집합크기+1) -1
```

### 🚩My submission
```python
import sys
input = sys.stdin.readline

m = int(input()) # 수행해야 하는 연산의 수
s = 0 # 비어있는 초기 공집합 S
for _ in range(m):
    command = list(map(str, input().strip().split())) # 수행해야 하는 연산 -> all과 empty가 있으므로 리스트로 저장
    # 따라서 command[0]: 연산내용 command[1]: 요소
    if command[0] == 'add':         # 원소 추가 (or)
        s |= (1 << int(command[1]))
    elif command[0] == 'remove':    # 원소 삭제 (not + and)
        s &= ~(1 << int(command[1]))
    elif command[0] == 'check':     # 원소 체크
        if s & (1<< int(command[1])):
            print(1)
        else:
            print(0)
    elif command[0] == 'toggle':    # 원소 토글 (xor)
        s ^= (1 << int(command[1]))
    elif command[0] == 'all':       # 원소 채우기
        s = (1 << 21) - 1           
    elif command[0] == 'empty':     #원소 비우기
        s = 0
```

### 💡TIL
- 비트마스크에 대한 개념을 실제 코드에 적용하여, 그것도 ‘집합’ 개념에 적용하여 새로웠다.
- 비트마스킹을 이용하여 집합의 원소 문제를 해결하는 법
    - 원소 추가: `S |= (1 << num)`
    - 원소 삭제: `S &= ~(1 << num)`
    - 원소 토글: `S ^= (1 << num)`
    - 원소 체크: `print(1 if S & (1 << int(op[1])) != 0 else 0))`
    - 원소 비우기: `S = 0`
    - 원소 채우기: `S = (1 << 21) - 1`
- 비트마스킹 이용해서 원소를 다루는 것뿐만 아니라 집합 자체 연산에도 사용할 수 있다.
    - 집합끼리 연산
        
        ```python
        A | B   # 합집합
        A & B   # 교집합
        A & ~B  # 차집합 (A - B)
        A ^ B   # A와 B 중 하나에만 포함된 원소들의 집합
        ```
        
    - 집합의 크기
        
        집합의 크기를 구하기 위해선, 비트에서 1인 비트 수를 세주면 된다. 이는 재귀 함수로 구현할 수 있다. `x % 2`는 마지막 비트를 의미, `x // 2`는 마지막 비트의 삭제를 의미한다.
        
        ```python
        def bitCount(x):
        	if x == 0: return 0
        	return x % 2 + bitCount(x//2)
        ```
        

참고자료: 

- [[https://velog.io/@rhdmstj17/비트마스크bit-mask-python-집합-자료구조](https://velog.io/@rhdmstj17/%EB%B9%84%ED%8A%B8%EB%A7%88%EC%8A%A4%ED%81%ACbit-mask-python-%EC%A7%91%ED%95%A9-%EC%9E%90%EB%A3%8C%EA%B5%AC%EC%A1%B0)](https://velog.io/@rhdmstj17/%EB%B9%84%ED%8A%B8%EB%A7%88%EC%8A%A4%ED%81%ACbit-mask-python-%EC%A7%91%ED%95%A9-%EC%9E%90%EB%A3%8C%EA%B5%AC%EC%A1%B0)
- [[https://velog.io/@1998yuki0331/Python-비트-마스킹-정리](https://velog.io/@1998yuki0331/Python-%EB%B9%84%ED%8A%B8-%EB%A7%88%EC%8A%A4%ED%82%B9-%EC%A0%95%EB%A6%AC)](https://velog.io/@1998yuki0331/Python-%EB%B9%84%ED%8A%B8-%EB%A7%88%EC%8A%A4%ED%82%B9-%EC%A0%95%EB%A6%AC)


---

## [백준 #11659. 구간 합 구하기4](https://www.acmicpc.net/problem/11659): 누적합(prefix Sum)/ 실버3
정리한 노션 링크: [노션](https://minggirokkk.notion.site/11659-4-95f1feb5166e412a9c7bd576bc2bc28b?pvs=4)

### 🔍Intuition
이 문제를 그냥 구현하면 `시간초과`가 나온다. 이유는 시간복잡도가 $O(NM)$이 나오기 때문이다. 따라서 이런 `구간합` 과 관련한 문제는 시간 복잡도를 낮출 알고리즘인 `prefix_sum`을 사용한다.

>🚨 **Problem**
- 앞서 말했듯이, 일반적으로 그냥 구현할 경우, 시간 복잡도 $O(NM)$이 나오게 된다.
- 그렇게 되면 `N`과 `M`의 범위가 `100,000`이 넘어갈 경우, 제한시간 1초 내에 구현할 수가 없다.
- ⇒ 따라서 알고리즘 설계할 때 여러 번 사용될만한 정보는 미리 구해서 저장해놓을수록 유리하다.
    
    ```python
    nums = list(map(int, input().strip().split()))
    prefix = [0] * (N+1)
    
    # 누적합 구하기
    for i in range(len(nums)):
        prefix[i+1] = nums[i] + prefix[i]
    ```
    

>💡 **Solution**
- 즉, 미리 `누적합`을 구해 저장을 해두고, 나중에 입력에 구간이 들어오면 해당 구간을 `index`로 접근하여 출력해주면 된다.
- 이때 `index`가 헷갈릴 수 있기 때문에 배열의 0인덱스는 0으로 둔다.
- 구간 입력이 시작 위치가 `start`, 끝 위치가 `end`로 들어오면, 해당 구간을 인덱스로 접근하여, `prefix[end] - prefix[start-1]` 로 수행하면 된다.
    
    ```python
    # 구간합 구하기 (누적합 - 구간)
    for _ in range(M):
        start, end = map(int, input().strip().split())
        result = prefix[end] - prefix[start-1]
        print(result)
    ```
    
- 이렇게 수행하면 계산시간은 $O(1)$이 된다.
- 결과적으로 M개의 데이터와 N개의 입력이 있을 때, 전체 구간합을 구하는 작업은 $O(N+M)$이 되기 때문에 제한시간을 충족할 수 있다.

### 🚩My submission
> **첫 번째 시도: 시간초과**
- 시간 초과가 나왔던 이유: for문 내에서 `sum`함수를 계속 호출하였기 때문
- 따라서 for문 안에서 `sum`을 호출하지 않으면서도, 구간의 합을 구할 수 있는 방법으로 다시 코드를 짜야 한다.
- 이 부분에 대한 설명은 위의 Intuition에 설명해두었으므로 넘어가도록 한다.
```python
import sys
input = sys.stdin.readline

N, M = map(int, input().strip().split())
nums = list(map(int, input().strip().split()))

for _ in range(M):
    start, end = map(int, input().strip().split())
    result = sum(nums[start-1:end])
    print(result)
```

> **최종 제출**
1. 문제에서 필요한 `N` , `M`, N개의 수를 저장할 `nums`리스트를 입력받는다.
2. 이 문제에서 $O(NM)$ 시간복잡도가 아닌 $O(N)$으로 처리하기 위해 누적합을 구한 후, 구간을 빼서 정답을 구한다. 즉, 이를 위해서는 누적합을 저장할 리스트가 필요하다. 이를 저장할 리스트, `prefix` 를 `N+1`크기로 초기화한다.
3. 누적합을 구한다. 
4. 구간합을 구한다. 구간합은 누적합에서 입력한 구간(시작위치: `start`, 끝 위치: `end`)을 빼서 구하면 된다.

```python
import sys
input = sys.stdin.readline

N, M = map(int, input().strip().split()) # N: 수의 개수 / M:
nums = list(map(int, input().strip().split()))
prefix = [0] * (N+1)

# 누적합 구하기
for i in range(len(nums)):
    prefix[i+1] = nums[i] + prefix[i]

# 구간합 구하기 (누적합 - 구간)
for _ in range(M):
    start, end = map(int, input().strip().split())
    result = prefix[end] - prefix[start-1]
    print(result)
```

### 💡TIL
참고 사이트: [[[알고리즘 이론] 구간합, 누적합(prefix sum)](https://jih3508.tistory.com/50)](https://jih3508.tistory.com/50)

- 누적합을 말만 들었지, 어떤 식으로 접근해야 할지 이해하지 못했는데 생각보다 간단했다. 누적합을 이용하여 구간합을 구하는 법도 배워간다.
- **누적합:**
    - 0번째 인덱스부터 N번째 인덱스까지 탐색하면서 인덱스 i일때 0번쨰 인덱스부터 0번째 인덱스 합을 말한다.
    
    ```python
    array = [1, 8, 7, 4, 3, 5, 6]
    n = len(array)
    prefix_sum = [0] * (n + 1)
    
    for i in range(n):
        prefix_sum[i + 1] = prefix_sum[i] + array[i]
    ```
    
- **구간합**
    - 누적합에서 구간간의 차이를 뺀다.
    
    ```python
    array = [1, 8, 7, 4, 3, 5, 6]
    n = len(array)
    prefix_sum = [0] * (n + 1)
    x, y = 1, 5
    
    for i in range(n):
        prefix_sum[i + 1] = prefix_sum[i] + array[i]
            
    part_sum = prefix_sum[y] - prefix_sum[x - 1]
    ```
---

## [백준 #2559. 수열](https://www.acmicpc.net/problem/2559): 누적합(prefix Sum) / 실버3
정리한 노션 링크: [노션](https://minggirokkk.notion.site/2559-cd068f613f6d4714973a681271af08e6?pvs=4)

### 🔍Intuition
[[#11659. 구간 합 구하기4](https://www.notion.so/11659-4-95f1feb5166e412a9c7bd576bc2bc28b?pvs=21)](https://www.notion.so/11659-4-95f1feb5166e412a9c7bd576bc2bc28b?pvs=21) 문제에서 배웠던 ‘구간합’의 개념을 다시 한번 적용해볼 수 있는 문제이다.

문제에서는 친절하게 그림도 제시해준다.
문제를 본 후, 가장 먼저 떠올랐던 건 ‘누적합’이었다.

>💡 **Key Idea:**
- 전체 온도 리스트(`temp`)에 대한 누적합(`prefix_sum`)을 먼저 구한 후,
- 주어진 연속적인 날짜의 수(`K`)만큼 구간을 나눠 구간합(`range_sum`)을 구한다.
- `range_sum`에서 최댓값이 `K`*일의 온도의 합이 최대가 되는 값*이므로 정답으로 출력한다.

위 Key Idea를 예제에 각각 적용해본 모습은 아래 표를 참고하면 된다.

### 🚩**플로우**
1. 필요한 변수 및 배열 초기화
    - 문제에서 주어진 `N`, `K`, `temp`말고 필요한 것은 3가지이다.
    - 누적합을 저장할 리스트인 `prefix_sum`
    - 누적합을 토대로 정해진 구간만큼을 저장하기 위한 구간합 리스트인 `range_sum`
    - range_sum의 크기를 나타내기 위해, 예제의 규칙성을 토대로 만든 `section`
    
    ```python
    # N: 온도를 측정한 전체 날짜 수 / K: 연속적인 날짜의 수
    N, K = map(int, input().strip().split()) 
    temp = list(map(int, input().strip().split())) # 온도 리스트
    prefix_sum = [0] * (N+1)  # 누적합 리스트
    section = N - K + 1       # 구간합 리스트를 초기화하기 위한 크기
    range_sum = [0] * section # 구간합 리스트
    ```
    
2. 전체 온도 리스트(`temp`)에 대한 누적합(`prefix_sum`)을 먼저 구한다.
    
    ```python
    # 누적합 구하기
    for i in range(len(temp)):
        prefix_sum[i+1] = temp[i] + prefix_sum[i]
    ```
    
3. 주어진 연속적인 날짜의 수(`K`)만큼 구간을 나눠 구간합(`range_sum`)을 구한다. 
    - 여기서 for문의 범위부분과, range_sum의 인덱스부분에서 약간
    
    ```python
    # 구간합 구하기
    for i in range(K, section+K):
        range_sum[i-K] = prefix_sum[i] - prefix_sum[i-K] 
    ```
    
4. `range_sum`에서 최댓값이 `K`*일의 온도의 합이 최대가 되는 값*이므로 정답으로 출력한다.
    
    ```python
    print(max(range_sum)) # K일의 온도의 합이 최대가 되는 값
    ```
    

혹시나 하여, N = 10, K = 5로 출력해본 결과 문제에서 주어진값대로 잘 저장되는 것을 볼 수 있다.

```python
10 5
3 -2 -4 -9 0 3 7 13 8 -3
prefix_sum [0, 3, 1, -3, -12, -12, -9, -2, 11, 19, 16]
-12 전체:  [-12, 0, 0, 0, 0, 0]
-12 전체:  [-12, -12, 0, 0, 0, 0]
-3 전체:  [-12, -12, -3, 0, 0, 0]
14 전체:  [-12, -12, -3, 14, 0, 0]
31 전체:  [-12, -12, -3, 14, 31, 0]
28 전체:  [-12, -12, -3, 14, 31, 28]
answer 31
```

### 🚩My submission
```python
import sys
input = sys.stdin.readline
# N: 온도를 측정한 전체 날짜 수 / K: 연속적인 날짜의 수
N, K = map(int, input().strip().split()) 
temp = list(map(int, input().strip().split())) # 온도 리스트
prefix_sum = [0] * (N+1)  # 누적합 리스트
section = N - K + 1       # 구간합 리스트를 초기화하기 위한 크기
range_sum = [0] * section # 구간합 리스트

# 누적합 구하기
for i in range(len(temp)):
    prefix_sum[i+1] = temp[i] + prefix_sum[i]

# 구간합 구하기
for i in range(K, section+K):
    range_sum[i-K] = prefix_sum[i] - prefix_sum[i-K] 

print(max(range_sum)) # K일의 온도의 합이 최대가 되는 값
```

### 💡TIL
- 누적합인지 판단이 되고나서부터는 문제가 잘 풀린다. 누적합이냐 아니냐를 판단하는 과정이 중요한 것 같다. 문제에서 연속적인 합이라는 키워드가 있다면 누적합을 고려해봐야겠다.

---

## [백준 #1012. 유기농 배추](https://www.acmicpc.net/problem/1012): DFSBFS/ 실버2
정리한 노션 링크: [노션](https://minggirokkk.notion.site/1012-c246f235c09e446db0ed87cf5efbc4a1?pvs=4)
> 💡 **문제 내용 요약**
배추밭에 배추가 심어져 있는 위치가 주어졌을 때, 상하좌우로 인접한 배추들이 몇 그룹인지를 파악하여 각 그룹마다 필요한 배추흰지렁이의 수를 계산하는 문제. 격자 형태의 배추밭에서, 연결된 배추 그룹(연결 요소)을 찾아야 한다.

### 🔍Intuition
- **그래프 연결요소(Connected Component) 찾기**
    - 그래프에서 서로 연결된 노드 집합을 의미한다.
    - 이 문제에서는 배추밭 격자의 각 셀을 노드로, 배추가 심어진 셀들이 서로 인접해있을 때를 연결된 것으로 본다.
- **DFS 또는 BFS로 접근하기**
    - 그래프의 모든 노드를 방문하는 DFS나 BFS를 사용하여 연결되어 있는 모든 배추를 찾는다.
    - DFS: 스택, 재귀
    - BFS: 큐
    
### 🚩**플로우**
> **DFS 접근**

1. **DFS 함수 정의**
    1. `x`(가로 위치)나 `y`(세로 위치)의 값이 범위에서 벗어나거나, 양배추밭을 나타내는 `cabbage_filed`에서 양배추가 없는 위치(즉, 값이 0)이라면, 바로 반환하여 탐색하지 않는다.
    2. 현재 위치는 탐색을 했기 때문에 배추가 있던 이 자리(`1`)를 `0`으로 설정하여 방문 처리한다.
    3. 현재 위치를 기준으로 상하좌우의 위치를 탐색하기 위해 DFS 재귀호출한다.
2. **입력 및 초기화**
    1. 테스트케이스 수 `T`를 입력받고, 각 테스트케이스마다 배추밭 가로길이 `M`, 세로길이 `N`, 배추의 개수 `K`를 입력받는다.
    2. 배추밭을 나타내는 `M x N`크기의 2차원 배열인 `cabbage_field`를 0으로 모두 초기화한다. (0: 배추 없음, 1: 배추 있음)
3. **배추 위치 설정**
    1. 주어진 `K`개의 위치에 대해 `cabbage_field` 2차원 배열 내에서 해당 위치의 값을 1로 설정하여 배추가 심어져있다는 것을 표현한다.
4. **DFS로 연결된 배추 탐색 & 지렁이 수 계산**
    1. 2차원 배열을 이중 for문으로 순회하면서, 값이 1이지만 아직 방문하지 않은 배추 위치를 찾는다.
    2. 만약 찾았다면, 
        1. 지렁이 수를 나타내는 `worms` 변수를 1증가시켜서 필요한 지렁이수를 계산한다.
        2. 현재 위치에서 **DFS**를 호출하여 연결된 배추를 방문처리하며 (`cabbage_filed[x][y]=0`), 연결된 배추 그릅을 탐색한다.
5. **결과 출력:** 각 테스트케이스마다 필요한 지렁이 수를 출력한다.


### 🚩My submission
> **DFS 접근**
```python
import sys
sys.setrecursionlimit(10000) #재귀 limit 설정(파이썬 최대 깊이 늘리는 모듈 이용)

input = sys.stdin.readline

# 1. DFS 함수 정의
def dfs(x, y):
    # x와 y의 위치가 벗어나거나, 양배추리스트에 없는 위치라면 그냥 반환
    if x < 0 or x >= M or y < 0 or y >= N  or cabbage_filed[x][y] == 0:
        return
    
    # 현재 위치 방문 처리 
    cabbage_filed[x][y] = 0 # 배추 있던 자리 1->0으로 변경해서 중복 방지

    # 상하좌우 위치 탐색
    dfs(x+1, y) # 오른쪽 배추 탐색
    dfs(x-1, y) # 왼쪽 배추 탐색
    dfs(x, y+1) # 위쪽 배추 탐색
    dfs(x, y-1) # 아래쪽 배추 탐색


T = int(input()) # 테스트케이스 수
# 2. 입력 설정 및 초기화
for _ in range(T):
    M, N, K = map(int, input().strip().split()) # M: 가로길이, N: 세로길이, K: 배추개수
    cabbage_filed = [[0] * N for _ in range(M)] # 양배추밭 리스트 초기화
    
    # 3. 배추 위치 설정
    for _ in range(K):
        x, y = map(int, input().strip().split())
        cabbage_filed[x][y] = 1 # 입력받은 x, y 위치에 배추가 있으므로 1로 변경
    
    worms = 0 # 지렁이 필요 수 초기화
    
    # 4. DFS로 연결된 배추 탐색 & 지렁이 수 계산
    for i in range(M):
        for j in range(N):
            if cabbage_filed[i][j] == 1: # 배추가 심어져 있고 아직 방문하지 않은 경우
                worms += 1 # 지렁이 수 +1
                dfs(i, j)# dfs 호출하여 모든 연결된 배추 방문 처리
                

		# 5. 결과 출력
    print(worms) # 현재 테스트케이스에 대한 지렁이 수 출력
```
> **문제 제출 성공 후, 다시 BFS로 접근**
> 
1. **BFS 함수 정의**
    1. `x`(가로 위치), `y`(세로 위치) ⇒ 시작 위치를 의미하며, `(x, y)`를 큐로 변환한다.
    2. 현재 위치(`cabbage_field[x][y]`)를 방문처리한다.
    3. 큐가 빌 때까지 루프를 실행하며, 큐에서 현재 위치 `cx, cy`를 꺼낸다.
    4. 현재 위치를 기준으로 상하좌우로 이동하는 방향(`[(1, 0), (-1, 0), (0, 1), (0, -1)`)을 정의하여, 각 방향에 대해 아래 과정을 수행한다. 
        1. 현재 위치 `(cx, cy)`에서 각 방향 `(dx, dy)`를 더해 새로운 위치인 `(nx, ny)` 를 계산한다.
        2. 새 위치(`nx`, `ny`)가 범위 안에 있고, `cabbage_field[nx][ny]`가 `1`인지 확인한다. 이때 `1`은 배추가 심어져있으나 방문을 아직 하지 않은 배추를 의미한다.
        3. 새 위치의 배추를 방문 처리하고(`0`), 해당 위치를 큐에 추가한다. 이렇게 하면 해당 배추와 인접한 다른 배추들도 순차적으로 탐색이 된다.
        4. 큐에 더이상 처리할 원소가 없으면 함수는 종료된다
- 2번~5번까지는 위의 DFS와 내용 동일 
    

```python
import sys
from collections import deque

input = sys.stdin.readline

# 1. BFS 함수 정의
def bfs(x, y):
    queue = deque([(x, y)])
    cabbage_field[x][y] = 0  # 방문 
    
    처리

    while queue:
        cx, cy = queue.popleft()
        # 상하좌우 탐색
        for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
            nx, ny = cx + dx, cy + dy
            if 0 <= nx < M and 0 <= ny < N and cabbage_field[nx][ny] == 1:
                cabbage_field[nx][ny] = 0  # 방문 처리
                queue.append((nx, ny))

T = int(input()) # 테스트케이스 수
# 2. 입력 설정 및 초기화
for _ in range(T):
    M, N, K = map(int, input().strip().split()) # M: 가로길이, N: 세로길이, K: 배추개수
    cabbage_filed = [[0] * N for _ in range(M)] # 양배추밭 리스트 초기화
    
    # 3. 배추 위치 설정
    for _ in range(K):
        x, y = map(int, input().strip().split())
        cabbage_filed[x][y] = 1 # 입력받은 x, y 위치에 배추가 있으므로 1로 변경
    
    worms = 0 # 지렁이 필요 수 초기화
    
    # 4. BFS로 연결된 배추 탐색 & 지렁이 수 계산
    for i in range(M):
        for j in range(N):
            if cabbage_filed[i][j] == 1: # 배추가 심어져 있고 아직 방문하지 않은 경우
                worms += 1 # 지렁이 수 +1
                bfs(i, j)# BFS 호출하여 모든 연결된 배추 방문 처리
                

		# 5. 결과 출력
    print(worms) # 현재 테스트케이스에 대한 지렁이 수 출력
```

### 💡TIL
- 너무 오랜만에 DFS/BFS문제를 접근해서 어떻게 풀어야 하는지 조차 전략이 잘 짜지지 않았다. 그래서 문제에 대한 힌트, DFS/BFS에 대한 내용을 보면서 문제에 접근하였다. 힌트를 많이 얻고 풀었지만 그만큼 배운 것이 많은 문제였다.
- 이 문제의 경우 **연결요소 찾기(`Connected Components`)**에 해당하는 알고리즘 유형이라고 한다. 즉, 격자 형태의 그래프에서 서로 연결된 노드 집합을 찾는 문제이다. 이때 노드는 배추를 심은 위치, 그리고 엣지(간선)는 노드들이 상하좌우로 연결된 형태를 의미한다.
    - 이를 해결하기 위해서 DFS나 BFS를 사용할 수 있다.
    - DFS는 스택이나 재귀호출로 구현할 수 있고, BFS는 큐로 구현할 수 있다.
    - **DFS (스택/재귀호출로 구현)**
        - 각 노드에서 시작해 가능한 한 깊이 탐색을 진행하고, 방문하지 않은 노드를 계속해서 탐색한다. 이 문제에서는 배추밭에 배추가 심어진 위치를 시작 노드로 해 상하좌우에 연결된 모두 배추를 방문처리한다.
        - 이때 Python에서 **재귀호출의 경우, 재귀 깊이에 한계가 있다. 
        ⇒ 따라서 이를 해결하기 위해서 `sys.setrecursionlimit(탐색하고자하는 깊이)`를 이용하여 재귀의 깊이를 증가**시킬 수 있다.
    - **BFS (큐로 구현)**
        - 시작노드에서 가까운 노드부터 넓게 탐색을 진행하는 방식이다.
        - **BFS는 일반적으로 레벨별로 탐색을 진행하기 때문에, 큰 데이터셋에서는 재귀의 깊이 제한에 덜 민감하다는 장점**이 있다.


